### PR TITLE
Throwing destructors need noexcept(false)

### DIFF
--- a/h5xx/attribute/attribute.hpp
+++ b/h5xx/attribute/attribute.hpp
@@ -48,7 +48,11 @@ public:
     attribute & operator=(attribute other);
 
     /** default destructor */
-    ~attribute() noexcept(false);
+    ~attribute()
+#if __cplusplus >= 201103L
+    noexcept(false)
+#endif
+    ;
 
     /** deduce dataspace from attribute */
     operator dataspace() const;
@@ -151,7 +155,10 @@ inline attribute & attribute::operator=(attribute other)
     return *this;
 }
 
-inline attribute::~attribute() noexcept(false)
+inline attribute::~attribute()
+#if __cplusplus >= 201103L
+noexcept(false)
+#endif
 {
     close();
 }

--- a/h5xx/attribute/attribute.hpp
+++ b/h5xx/attribute/attribute.hpp
@@ -148,7 +148,7 @@ inline attribute & attribute::operator=(attribute other)
     return *this;
 }
 
-inline attribute::~attribute()
+inline attribute::~attribute() noexcept(false)
 {
     if (hid_ >= 0) {
         if(H5Aclose(hid_) < 0){

--- a/h5xx/attribute/attribute.hpp
+++ b/h5xx/attribute/attribute.hpp
@@ -48,7 +48,7 @@ public:
     attribute & operator=(attribute other);
 
     /** default destructor */
-    ~attribute();
+    ~attribute() noexcept(false);
 
     /** deduce dataspace from attribute */
     operator dataspace() const;
@@ -98,6 +98,9 @@ public:
      * get_name(attribute const&).
      */
     std::string name() const;
+    
+    /** close the attribute */
+    void close();
 
 private:
     /** HDF5 object ID */
@@ -149,6 +152,11 @@ inline attribute & attribute::operator=(attribute other)
 }
 
 inline attribute::~attribute() noexcept(false)
+{
+    close();
+}
+
+inline void attribute::close()
 {
     if (hid_ >= 0) {
         if(H5Aclose(hid_) < 0){

--- a/h5xx/dataset/dataset.hpp
+++ b/h5xx/dataset/dataset.hpp
@@ -41,7 +41,11 @@ public:
     );
 
     /** destructor, implicitly closes the dataset's hid_ */
-    ~dataset() noexcept(false);
+    ~dataset()
+#if __cplusplus >= 201103L
+    noexcept(false)
+#endif
+    ;
 
     /**
      * deleted copy constructor
@@ -149,7 +153,10 @@ dataset::dataset(
     }
 }
 
-inline dataset::~dataset() noexcept(false)
+inline dataset::~dataset()
+#if __cplusplus >= 201103L
+noexcept(false)
+#endif
 {
     close();
 }

--- a/h5xx/dataset/dataset.hpp
+++ b/h5xx/dataset/dataset.hpp
@@ -146,7 +146,7 @@ dataset::dataset(
     }
 }
 
-inline dataset::~dataset()
+inline dataset::~dataset() noexcept(false)
 {
     if (hid_ >= 0) {
         if(H5Dclose(hid_) < 0){

--- a/h5xx/dataset/dataset.hpp
+++ b/h5xx/dataset/dataset.hpp
@@ -41,7 +41,7 @@ public:
     );
 
     /** destructor, implicitly closes the dataset's hid_ */
-    ~dataset();
+    ~dataset() noexcept(false);
 
     /**
      * deleted copy constructor
@@ -77,6 +77,9 @@ public:
 
     /** return copy of dataset's type */
     hid_t get_type() const;
+    
+    /** close the dataset */
+    void close();
 
 private:
     /** HDF5 handle of the dataset */
@@ -147,6 +150,11 @@ dataset::dataset(
 }
 
 inline dataset::~dataset() noexcept(false)
+{
+    close();
+}
+
+inline void dataset::close()
 {
     if (hid_ >= 0) {
         if(H5Dclose(hid_) < 0){

--- a/h5xx/dataspace/dataspace.hpp
+++ b/h5xx/dataspace/dataspace.hpp
@@ -92,7 +92,11 @@ public:
     dataspace & operator=(dataspace other);
 
     /** default destructor */
-    ~dataspace() noexcept(false);
+    ~dataspace()
+#if __cplusplus >= 201103L
+    noexcept(false)
+#endif
+    ;
 
     /** return HDF5 object ID */
     hid_t hid() const
@@ -244,7 +248,10 @@ dataspace::dataspace(boost::array<hsize_t, N> const& dims, boost::array<hsize_t,
         throw error("creating simple dataspace");
 }
 
-inline dataspace::~dataspace() noexcept(false)
+inline dataspace::~dataspace()
+#if __cplusplus >= 201103L
+noexcept(false)
+#endif
 {
     close();
 }

--- a/h5xx/dataspace/dataspace.hpp
+++ b/h5xx/dataspace/dataspace.hpp
@@ -241,7 +241,7 @@ dataspace::dataspace(boost::array<hsize_t, N> const& dims, boost::array<hsize_t,
         throw error("creating simple dataspace");
 }
 
-inline dataspace::~dataspace()
+inline dataspace::~dataspace() noexcept(false)
 {
     if (hid_ >= 0) {
         if(H5Sclose(hid_) < 0)

--- a/h5xx/dataspace/dataspace.hpp
+++ b/h5xx/dataspace/dataspace.hpp
@@ -92,7 +92,7 @@ public:
     dataspace & operator=(dataspace other);
 
     /** default destructor */
-    ~dataspace();
+    ~dataspace() noexcept(false);
 
     /** return HDF5 object ID */
     hid_t hid() const
@@ -151,6 +151,9 @@ public:
      * return the number of elements currently selected from the dataspace
      */
     hssize_t get_select_npoints() const;
+    
+    /** close the dataspace */
+    void close();
 
 private:
     /** HDF5 object ID */
@@ -242,6 +245,11 @@ dataspace::dataspace(boost::array<hsize_t, N> const& dims, boost::array<hsize_t,
 }
 
 inline dataspace::~dataspace() noexcept(false)
+{
+    close();
+}
+
+inline void dataspace::close()
 {
     if (hid_ >= 0) {
         if(H5Sclose(hid_) < 0)


### PR DESCRIPTION
Recent compilers (e.g. GCC 6 and higher) warn when destructors throw exceptions.
```
/builds/espressomd/docker/espresso/libs/h5xx/h5xx/dataset/dataset.hpp: In destructor 'h5xx::dataset::~dataset()':
/builds/espressomd/docker/espresso/libs/h5xx/h5xx/dataset/dataset.hpp:153:98: error: throw will always call terminate() [-Werror=terminate]
             throw error("closing h5xx::dataset with ID " + boost::lexical_cast<std::string>(hid_));
```
Since C++11, destructors default to `noexcept`, so we need to explicitly mark the destructors as throwing.