### PR TITLE
Add missing virtual destructor to fill_value

### DIFF
--- a/h5xx/policy/storage.hpp
+++ b/h5xx/policy/storage.hpp
@@ -72,6 +72,8 @@ public:
             if (!optional)
                 throw error("setting fill_value failed");
     }
+    
+    virtual ~fill_value() {}
 private:
     hid_t type;
     std::vector<char> value;


### PR DESCRIPTION
Silences warnings like `error: delete called on non-final 'fill_value' that has virtual functions but non-virtual destructor`.